### PR TITLE
Smarter bonne bounds 2

### DIFF
--- a/source/map/chart.ts
+++ b/source/map/chart.ts
@@ -236,8 +236,10 @@ export class Chart {
 			this.geoEdges = [
 				{type: 'M', args: [φMax, λMax]},
 				{type: 'Φ', args: [φMax, λMin]},
+				{type: 'L', args: [φMax, λMax]},
 				{type: 'M', args: [φMin, λMin]},
 				{type: 'Φ', args: [φMin, λMax]},
+				{type: 'L', args: [φMin, λMin]},
 			];
 		else
 			this.geoEdges = Chart.rectangle(φMax, λMax, φMin, λMin, true);

--- a/source/map/chart.ts
+++ b/source/map/chart.ts
@@ -2,7 +2,7 @@
  * This work by Justin Kunimune is marked with CC0 1.0 Universal.
  * To view a copy of this license, visit <https://creativecommons.org/publicdomain/zero/1.0>
  */
-import {Edge, EmptySpace, INFINITE_PLANE, Surface, Tile, Vertex} from "../surface/surface.js";
+import {Domain, Edge, EmptySpace, INFINITE_PLANE, Surface, Tile, Vertex} from "../surface/surface.js";
 import {
 	filterSet, localizeInRange,
 	pathToString,
@@ -1050,7 +1050,11 @@ export class Chart {
 		const meanRadius = rSum/count;
 
 		// find the longitude with the most empty space on either side of it
-		const coastline = Chart.border(filterSet(regionOfInterest, tile => !tile.isWater()));
+		const coastline = intersection(
+			Chart.border(filterSet(regionOfInterest, tile => !tile.isWater())),
+			Chart.rectangle(-Math.PI, -Math.PI, Math.PI, Math.PI, true),
+			new Domain(-Math.PI, Math.PI, -Math.PI, Math.PI, (_) => false), true,
+		);
 		let centralMeridian;
 		const emptyLongitudes = new ErodingSegmentTree(-Math.PI, Math.PI); // start with all longitudes empty
 		for (let i = 0; i < coastline.length; i ++) {

--- a/source/map/chart.ts
+++ b/source/map/chart.ts
@@ -210,16 +210,7 @@ export class Chart {
 			this.projection);
 		// if we want a rectangular map
 		if (rectangularBounds) {
-			// expand the longitude bounds as much as possible without self-intersection, assuming no latitude bounds
-			let limitingΔλ = Infinity;
-			for (let i = 0; i <= 50; i ++) {
-				const φ = this.projection.φMin + i/50*(this.projection.φMax - this.projection.φMin);
-				const parallelCurvature = this.projection.parallelCurvature(φ);
-				limitingΔλ = Math.min(limitingΔλ, 2*Math.PI/Math.abs(parallelCurvature));
-			}
-			λMin = Math.max(Math.min(λMin, centralMeridian - limitingΔλ/2), this.projection.λMin);
-			λMax = Math.min(Math.max(λMax, centralMeridian + limitingΔλ/2), this.projection.λMax);
-			// then expand the latitude bounds as much as possible without self-intersection
+			// expand the latitude bounds as much as possible without self-intersection, assuming no latitude bounds
 			for (let i = 0; i <= 50; i ++) {
 				const φ = this.projection.φMin + i/50*(this.projection.φMax - this.projection.φMin);
 				if (Math.abs(this.projection.parallelCurvature(φ)) <= 1) {
@@ -227,6 +218,15 @@ export class Chart {
 					φMin = Math.min(φMin, φ);
 				}
 			}
+			// then expand the longitude bounds as much as possible without self-intersection
+			let limitingΔλ = Infinity;
+			for (let i = 0; i <= 50; i ++) {
+				const φ = φMin + i/50*(φMax - φMin);
+				const parallelCurvature = this.projection.parallelCurvature(φ);
+				limitingΔλ = Math.min(limitingΔλ, 2*Math.PI/Math.abs(parallelCurvature));
+			}
+			λMin = Math.max(Math.min(λMin, centralMeridian - limitingΔλ/2), this.projection.λMin);
+			λMax = Math.min(Math.max(λMax, centralMeridian + limitingΔλ/2), this.projection.λMax);
 		}
 
 		// if it's a Bonne projection, re-generate it with these new bounds in case you need to adjust the curvature

--- a/source/map/pathutilities.ts
+++ b/source/map/pathutilities.ts
@@ -31,16 +31,17 @@ const π = Math.PI;
  * it just shifts them to and fro by multiples of 2π to put them in the right range.
  * this function can't go in MapProjection.projectPoint because it often must be called
  * before the path is intersected with the geoEdges.
- * @param projection the projection whose domain we're trying to match
+ * @param φMin the lower bound defining the range of latitudes to use
+ * @param λMin the western bound defining the range of longitudes to use
  * @param segments the jeograffickal imputs in absolute coordinates
  * @returns the relative outputs in transformed coordinates
  */
-export function transformInput(projection: MapProjection, segments: PathSegment[]): PathSegment[] {
+export function transformInput(φMin: number, λMin: number, segments: PathSegment[]): PathSegment[] {
 	const output: PathSegment[] = [];
 	for (const segment of segments) {
 		let [φ, λ] = segment.args;
-		φ = localizeInRange(φ, projection.φMin, projection.φMin + 2*π); // snap the latitude into the right domain
-		λ = localizeInRange(λ, projection.λMin, projection.λMin + 2*π); // snap the longitude into the right domain
+		φ = localizeInRange(φ, φMin, φMin + 2*π); // snap the latitude into the right domain
+		λ = localizeInRange(λ, λMin, λMin + 2*π); // snap the longitude into the right domain
 		output.push({type: segment.type, args: [φ, λ]});
 	}
 	return output;

--- a/source/map/pathutilities.ts
+++ b/source/map/pathutilities.ts
@@ -1071,10 +1071,9 @@ export function isClosed(segments: PathSegment[], domain: Domain): boolean {
 export function convertPathClosuresToZ(segments: PathSegment[]): PathSegment[] {
 	const newSegments = [];
 	for (let i = 0; i < segments.length; i ++) {
+		newSegments.push(segments[i]);
 		if (i + 1 === segments.length || segments[i + 1].type === 'M')
 			newSegments.push({type: 'Z', args: []});
-		else
-			newSegments.push(segments[i]);
 	}
 	return newSegments;
 }

--- a/source/map/pathutilities.ts
+++ b/source/map/pathutilities.ts
@@ -141,7 +141,7 @@ export function intersection(segments: PathSegment[], edges: PathSegment[], doma
 	for (let i = 1; i < edges.length; i ++) {
 		const {s, t} = endpoint(edges[i]);
 		if (s < domain.sMin || s > domain.sMax || t < domain.tMin || t > domain.tMax)
-			throw new Error(`these edges go out to s=${s},t=${t}, which is not contained in the domain [${domain.sMin}, ${domain.sMax}), [${domain.tMin}, ${domain.tMax})`);
+			throw new Error(`these edges go out to s=${s},t=${t}, which is not contained in the domain [${domain.sMin}, ${domain.sMax}], [${domain.tMin}, ${domain.tMax}]`);
 	}
 
 	// start by breaking the edges up into separate loops

--- a/source/map/projection.ts
+++ b/source/map/projection.ts
@@ -420,11 +420,11 @@ export class MapProjection {
 		const y = [];
 		for (let i = southernΦ.length - 1; i > 0; i --) {
 			φ.push(southernΦ[i]);
-			y.push(Math.min(southernY[i], dx_dλ*1e19)); // make sure to clip them to finite values
+			y.push(Math.min(southernY[i], dx_dλ*1e10)); // make sure to clip them to finite values
 		}
 		for (let i = 0; i < northernΦ.length; i ++) {
 			φ.push(northernΦ[i]);
-			y.push(Math.max(northernY[i], -dx_dλ*1e19));
+			y.push(Math.max(northernY[i], -dx_dλ*1e10));
 		}
 		return new MapProjection(surface, φ, y, Array(φ.length).fill(dx_dλ), Infinity, λStd);
 	}

--- a/tests/plotting.test.ts
+++ b/tests/plotting.test.ts
@@ -607,6 +607,18 @@ describe("contains", () => {
 				.toBe(Side.OUT);
 		});
 	});
+	test("collinear in two directions", () => {
+		const region: PathSegment[] = [
+			{type: 'M', args: [0.0, 0.0]},
+			{type: 'L', args: [0.0, 1.0]},
+			{type: 'L', args: [1.0, 1.0]},
+			{type: 'L', args: [1.0, 0.1]},
+			{type: 'L', args: [0.9, 0.0]},
+			{type: 'L', args: [0.0, 0.0]},
+		];
+		expect(contains(region, {s: 1.0, t: 0.0}, plane))
+			.toBe(Side.OUT);
+	});
 	test("circular region", () => {
 		const segments = [
 			{type: 'M', args: [0.5, 0.0]},

--- a/tests/projection.test.ts
+++ b/tests/projection.test.ts
@@ -12,7 +12,7 @@ describe("on a sphere", () => {
 	const sphere = new Spheroid(1, 1, 0, 0);
 
 	describe("sinusoidal projection", () => {
-		const projection = MapProjection.bonne(sphere, -Math.PI/2, 0, Math.PI/2, 0);
+		const projection = MapProjection.bonne(sphere, -Math.PI/2, 0, Math.PI/2, 0, 2*Math.PI);
 		test("projectPoint()", () => {
 			expect(projection.projectPoint({φ: 1, λ: -1})).toEqual(
 				{x: expect.closeTo(-Math.cos(1)), y: expect.closeTo(-Math.PI/2 - 1)});


### PR DESCRIPTION
I set it up so it adjusts the bounds and curvature of the Bonne projection to prevent self-intersection.  I fear I've gone too far, tho, as it starts by limiting the longitude, and it turns out with toroids the center usually ends up being put adjacent to one of the limiting parallels meaning it just decreases the meridians all the way, which isn't great.  I think for better results I want to do something a little smarter as far as deciding how much to limit φ versus λ.there are other more complicated things I could do.  I could try to determine if the self-intersection is in the Cartesian map bounds and let it be if it's not.  I could try to move clipped latitudes to the other side so that the whole 2π of latitudes is shown in theory (tho in that case what you would really want is to show each latitude multiple times as necessary (I've never done this in vector graphics.  it sounds really really hard.).).